### PR TITLE
Convertir fin de línea a LF para Windows

### DIFF
--- a/BACKEND/Dockerfile
+++ b/BACKEND/Dockerfile
@@ -9,8 +9,8 @@ COPY pom.xml .
 COPY mvnw .
 COPY .mvn/wrapper/ .mvn/wrapper/
 
-# Dar permisos de ejecución al script
-RUN chmod +x mvnw
+# Dar permisos de ejecución al script y convertir fin de línea a LF
+RUN chmod +x mvnw && sed -i 's/\r$//' mvnw
 
 # Empaquetar la aplicación
 RUN ./mvnw clean package -DskipTests


### PR DESCRIPTION
Hay que ver si funciona en Linux, no es posible para mi ahora. Pero con esta aumentación, se funciona en Windows 10 